### PR TITLE
Added type alias Tsvector

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod types {
     #[derive(Clone, Copy, SqlType)]
     #[postgres(oid = "3614", array_oid = "3643")]
     pub struct TsVector;
+    pub type Tsvector = TsVector;
 
     #[derive(SqlType)]
     #[postgres(type_name = "regconfig")]


### PR DESCRIPTION
Added type alias Tsvector for TsVector to be compatible with diesel print-schema as proposed in [https://github.com/diesel-rs/diesel_full_text_search/issues/8](url).